### PR TITLE
Refactor ChatService to return messages in reverse order

### DIFF
--- a/server/include/chat_service.h
+++ b/server/include/chat_service.h
@@ -133,7 +133,7 @@ namespace chat
         bool SaveMessage(const std::string &token, const std::string &text); // Сохраняет сообщение в БД, применяется при отправке
 
         /**
-         * @brief Получает последние сообщения из указанной комнаты.
+         * @brief Получает последние сообщения в порядке от новых к старым из указанной комнаты.
          * @param room_name Имя комнаты.
          * @param max_items Максимальное количество сообщений для загрузки.
          * @return std::vector<postgres::MessageRecord> Список записей сообщений.
@@ -141,7 +141,7 @@ namespace chat
         std::vector<postgres::MessageRecord> GetRecentMessages(const std::string &room_name, int max_items) const;
 
         /**
-         * @brief Получает страницу сообщений из указанной комнаты.
+         * @brief Получает страницу сообщений в порядке от новых к старым из указанной комнаты.
          * @param room_name Имя комнаты.
          * @param offset Смещение для загрузки страницы.
          * @param limit Количество записей на странице.

--- a/server/src/chat_service.cpp
+++ b/server/src/chat_service.cpp
@@ -160,11 +160,15 @@ bool ChatService::SaveMessage(const std::string& token, const std::string& text)
 }
 
 std::vector<postgres::MessageRecord> ChatService::GetRecentMessages(const std::string& room_name, int max_items) const {
-    return db_wrapper_.GetRecentMessages(room_name, max_items);
+    auto messages = db_wrapper_.GetRecentMessages(room_name, max_items);
+    std::reverse(messages.begin(), messages.end());
+    return messages;
 }
 
 std::vector<postgres::MessageRecord> ChatService::GetRoomMessagesPage(const std::string& room_name, int offset, int limit) const {
-    return db_wrapper_.GetRoomMessagesPage(room_name, offset, limit);
+    auto messages = db_wrapper_.GetRoomMessagesPage(room_name, offset, limit);
+    std::reverse(messages.begin(), messages.end());
+    return messages;
 }
 
 std::optional<postgres::UserRecord> ChatService::GetUserByToken(const std::string& token) const {


### PR DESCRIPTION
**Обновления по серверу**

Методы ChatService::GetRecentMessages и ChatService::GetRoomMessagesPage возвращают список сообщений в порядке от новых к старым